### PR TITLE
Bugfix for issue #1

### DIFF
--- a/src/codecs/item_codec.py
+++ b/src/codecs/item_codec.py
@@ -33,7 +33,7 @@ class ItemCodec:
         split_kind_char: str = "|",
         split_data_item_char: str = "="
     ) -> str:
-        item_str = f"{item.kind}{split_kind_char}{item.name}"
+        item_str = f"{item.kind.value}{split_kind_char}{item.name}"
         if item.metric is not None:
             item_str += (
                 f"{split_data_item_char}{MetricDataItemCodec.encode(item.metric)}"

--- a/src/codecs/metric_data_item_codec.py
+++ b/src/codecs/metric_data_item_codec.py
@@ -31,7 +31,7 @@ class MetricDataItemCodec:
             value = str(value)
         elif mdi.data_type == MetricDataTypes.TEXT.value:
             value = str(value)
-        return f"{mdi.data_type}{data_type_and_value_char}{value}"
+        return f"{mdi.data_type.value}{data_type_and_value_char}{value}"
 
     @staticmethod
     def from_value(value: MetricValueType) -> MetricDataItem:

--- a/src/types/item_type.py
+++ b/src/types/item_type.py
@@ -9,4 +9,3 @@ class ItemTypes(str, Enum):
     DEVICE_ID = "d"
     METRIC_ITEM = "m"
     HEALTH_CHECK = "h"
-

--- a/src/types/item_type.py
+++ b/src/types/item_type.py
@@ -10,9 +10,3 @@ class ItemTypes(str, Enum):
     METRIC_ITEM = "m"
     HEALTH_CHECK = "h"
 
-
-@dataclass(frozen=True)
-class Item:
-    kind: ItemTypes
-    name: str
-    metric: Optional[MetricDataItem] = None

--- a/tests/codecs/test_iot_ext_codec.py
+++ b/tests/codecs/test_iot_ext_codec.py
@@ -35,7 +35,7 @@ MSG_1_EXAMPLE_AS_DATA_STRUCTS = \
 
 class IoTextCodecTest(TestCase):
 
-    # TODO: verify where is a bug!?
+
     @skip
     def test_decode(self):
         expected = MSG_1_EXAMPLE_AS_DATA_STRUCTS

--- a/tests/codecs/test_iot_ext_codec.py
+++ b/tests/codecs/test_iot_ext_codec.py
@@ -2,7 +2,8 @@ from decimal import Decimal
 from unittest import TestCase, skip
 
 from src.codecs.iot_ext_codec import IoTextCodec
-from src.types.item_type import Item, ItemTypes, MetricDataItem
+from src.types.item import Item
+from src.types.item_type import ItemTypes, MetricDataItem
 from src.types.metric_data import MetricDataTypes
 
 MSG_1_EXAMPLE = '''t|3900237526042,d|device_name_001,m|val_water_001=i:1234,m|val_water_002=i:15,m|bulb_state=b:1,''' \
@@ -36,7 +37,6 @@ MSG_1_EXAMPLE_AS_DATA_STRUCTS = \
 class IoTextCodecTest(TestCase):
 
 
-    @skip
     def test_decode(self):
         expected = MSG_1_EXAMPLE_AS_DATA_STRUCTS
 


### PR DESCRIPTION
test_encode in test_iot_ext_codec.py was failing because function encode in item_codec.py and function encode in metric_data_item_codec.py were using Enum names instead of str values. Issue was fixed, now the test passes.